### PR TITLE
Remove "declarativeNetRequestFeedback" permission

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -23,7 +23,6 @@
   ],
 
   "permissions": [
-    "declarativeNetRequest",
-    "declarativeNetRequestFeedback"
+    "declarativeNetRequest"    
   ]
 }


### PR DESCRIPTION
The `declarativeNetRequestFeedback` permission triggers a "Read your browsing history" permission warning, which gives the wrong impression to the average user. 

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/77681918/201741549-f1818131-29e9-4aa3-8bcb-b550f3ca820b.png)

</details>

I assume you used it for debugging during development, I also wrote about it here...  
https://community.signalusers.org/t/introducing-debuglogs-app/48161/8

